### PR TITLE
update org.activiti.cloud.dependencies:activiti-cloud-dependencies to 7.0.24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <spring-cloud.version>Finchley.SR1</spring-cloud.version>
     <spring-cloud-k8s.version>0.3.0.RELEASE</spring-cloud-k8s.version>
     <spring-boot.version>2.0.4.RELEASE</spring-boot.version>
-    <activiti.cloud.version>7.0.19</activiti.cloud.version>
+    <activiti.cloud.version>7.0.24</activiti.cloud.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.cloud.dependencies:activiti-cloud-dependencies` to: `7.0.16`