### PR TITLE
update org.activiti.cloud.dependencies:activiti-cloud-dependencies to 7.1.106

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <java.version>11</java.version>
-    <activiti-cloud-dependencies.version>7.1.105</activiti-cloud-dependencies.version>	    
+    <activiti-cloud-dependencies.version>7.1.106</activiti-cloud-dependencies.version>	    
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>	    
     <maven.compiler.target>${java.version}</maven.compiler.target>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.cloud.dependencies:activiti-cloud-dependencies` to: `7.1.106`